### PR TITLE
Used older version of pandas requirements.txt

### DIFF
--- a/generator/requirements.txt
+++ b/generator/requirements.txt
@@ -1,6 +1,6 @@
 google_api_python_client==2.116.0
 google_auth_oauthlib==1.2.0
-pandas==2.2.2
+pandas==2.2.0
 Pillow==10.4.0
 protobuf==5.27.2
 Requests==2.32.3


### PR DESCRIPTION
 No matching distribution found for pandas==2.2.2 (from -r requirements.txt 